### PR TITLE
Extract to multiple json files.

### DIFF
--- a/src/compilers/json.compiler.ts
+++ b/src/compilers/json.compiler.ts
@@ -8,6 +8,7 @@ export class JsonCompiler implements CompilerInterface {
 	}
 
 	public parse(contents: string): TranslationCollection {
+		contents = contents || '{}';
 		return new TranslationCollection(JSON.parse(contents));
 	}
 

--- a/src/compilers/namespaced-json.compiler.ts
+++ b/src/compilers/namespaced-json.compiler.ts
@@ -11,6 +11,7 @@ export class NamespacedJsonCompiler implements CompilerInterface {
 	}
 
 	public parse(contents: string): TranslationCollection {
+		contents = contents || '{}';
 		const values = flat.flatten(JSON.parse(contents));
 		return new TranslationCollection(values);
 	}


### PR DESCRIPTION
This PR allows to override multiple json files. Possible fix for #7

**Sitation 1: (Same as before)**
_Start:_
Empty folder `./src/public/translations`

_Extract:_
Run `ng2-translate-extract --dir ./src --output ./src/public/translations --format=namespaced-json --clean --sort`

_Output:_
`template.json` will be generated in the output folder.

**Sitation 2: (Same as before)**
_Start:_
Empty folder `./src/public/translations`

_Extract:_
Run `ng2-translate-extract --dir ./src --output ./src/public/translations/test.json --format=namespaced-json --clean --sort`

_Output:_
`test.json` will be generated in the output folder.

**Sitation 3: (New)**
_Start:_
Translation folder `./src/public/translations` contains the translation files:
```
./src/public/translations
    - en.json
    - nl.json
    - fr.json
```

_Extract:_
Run `ng2-translate-extract --dir ./src --output ./src/public/translations --format=namespaced-json --clean --sort`

_Output:_
`en.json`, `nl.json` and `fr.json` will be updated with the new translation strings