### PR TITLE
Change regex of service parser to use word boundary instead of dot

### DIFF
--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -12,7 +12,7 @@ export class ServiceParser implements ParserInterface {
 		}
 
 		const methodRegExp: RegExp = /(?:get|instant)\s*\(\s*(\[?\s*(['"`])([^\1\r\n]*)\2\s*\]?)/;
-		const regExp: RegExp = new RegExp(`\\.${translateServiceVar}\\.${methodRegExp.source}`, 'g');
+		const regExp: RegExp = new RegExp(`${translateServiceVar}\\.${methodRegExp.source}`, 'g');
 
 		let matches: RegExpExecArray;
 		while (matches = regExp.exec(contents)) {

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -12,7 +12,7 @@ export class ServiceParser implements ParserInterface {
 		}
 
 		const methodRegExp: RegExp = /(?:get|instant)\s*\(\s*(\[?\s*(['"`])([^\1\r\n]*)\2\s*\]?)/;
-		const regExp: RegExp = new RegExp(`\\.${translateServiceVar}\\.${methodRegExp.source}`, 'g');
+		const regExp: RegExp = new RegExp(`\\b${translateServiceVar}\\.${methodRegExp.source}`, 'g');
 
 		let matches: RegExpExecArray;
 		while (matches = regExp.exec(contents)) {

--- a/src/parsers/service.parser.ts
+++ b/src/parsers/service.parser.ts
@@ -12,7 +12,7 @@ export class ServiceParser implements ParserInterface {
 		}
 
 		const methodRegExp: RegExp = /(?:get|instant)\s*\(\s*(\[?\s*(['"`])([^\1\r\n]*)\2\s*\]?)/;
-		const regExp: RegExp = new RegExp(`${translateServiceVar}\\.${methodRegExp.source}`, 'g');
+		const regExp: RegExp = new RegExp(`\\.${translateServiceVar}\\.${methodRegExp.source}`, 'g');
 
 		let matches: RegExpExecArray;
 		while (matches = regExp.exec(contents)) {


### PR DESCRIPTION
Hi,

I was noticing that the service parser was not recognizing my translation strings. For example:

```javascript
translate.get('Company is required').subscribe((res: string) => {
  this.validationMessages['Company']['required'] = res;
});
```

Looking at the code, I see that the regular expression is looking for a dot before the `translateServiceVar`, so basically it was looking for `.translate.get`.

My patch fixes it by changing the first dot in a word boundary `\b`.