### PR TITLE
feat(cli): add verbose (vb) flag that can control output of all file …

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ Options:
                                                       [boolean] [default: false]
   --clean, -c                 Remove obsolete strings when merging
                                                       [boolean] [default: false]
+  --verbose, -vb              If true, prints all processed file paths to console
+                                                      [boolean] [default: true]

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -82,6 +82,12 @@ export const cli = yargs
 		default: false,
 		type: 'boolean'
 	})
+	.option('verbose', {
+		alias: 'vb',
+		describe: 'Log all output to console',
+		default: true,
+		type: 'boolean'
+	})
 	.exitProcess(true)
 	.parse(process.argv);
 

--- a/src/cli/tasks/extract.task.ts
+++ b/src/cli/tasks/extract.task.ts
@@ -14,6 +14,7 @@ export interface ExtractTaskOptionsInterface {
 	sort?: boolean;
 	clean?: boolean;
 	patterns?: string[];
+	verbose?: boolean;
 }
 
 export class ExtractTask implements TaskInterface {
@@ -22,7 +23,8 @@ export class ExtractTask implements TaskInterface {
 		replace: false,
 		sort: false,
 		clean: false,
-		patterns: []
+		patterns: [],
+		verbose: true
 	};
 
 	protected _parsers: ParserInterface[] = [];
@@ -64,7 +66,7 @@ export class ExtractTask implements TaskInterface {
 		let collection: TranslationCollection = new TranslationCollection();
 		this._input.forEach(dir => {
 			this._readDir(dir, this._options.patterns).forEach(path => {
-				this._out(chalk.gray('- %s'), path);
+				this._options.verbose && this._out(chalk.gray('- %s'), path);
 				const contents: string = fs.readFileSync(path, 'utf-8');
 				this._parsers.forEach((parser: ParserInterface) => {
 					collection = collection.union(parser.extract(contents, path));


### PR DESCRIPTION
Wanted to limit the logging to the console as I'm integrating your package (thanks!) into a build process for a large-ish app.

The build process I've created around this package, the ng cli and other tasks prints out more important information to the console and the list of all processed files coming from this app pushes everything off the screen.

I've added a `-vb` / `--verbose` flag to the cli which adds the ability to turn off `this._out(chalk.gray('- %s'), path);`.

The functionality of this package remains the same since I default the flag to `true`.