### PR TITLE
Change typescript to be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "mocha": "3.4.2",
     "ts-node": "3.1.0",
     "tslint": "5.4.3",
-    "tslint-eslint-rules": "4.1.1",
-    "typescript": "2.4.1"
+    "tslint-eslint-rules": "4.1.1"
   },
   "dependencies": {
     "chalk": "2.0.1",
@@ -71,6 +70,7 @@
     "glob": "7.1.2",
     "path": "0.12.7",
     "mkdirp": "0.5.1",
-    "flat": "2.0.1"
+    "flat": "2.0.1",
+    "typescript": "2.4.1"
   }
 }


### PR DESCRIPTION
Typescript is being imported by the parser files, so it should be a direct dependency instead of just a development one.

Without that change, it's impossible to use the extractor programatically or with npx.