### PR TITLE
Configured cheerio to work with non-HTML standard elements

### DIFF
--- a/src/parsers/directive.parser.ts
+++ b/src/parsers/directive.parser.ts
@@ -2,7 +2,9 @@ import { ParserInterface } from './parser.interface';
 import { AbstractTemplateParser } from './abstract-template.parser';
 import { TranslationCollection } from '../utils/translation.collection';
 
-import * as $ from 'cheerio';
+import * as cheerio from 'cheerio';
+
+const $ = cheerio.load('', {xmlMode: true});
 
 export class DirectiveParser extends AbstractTemplateParser implements ParserInterface {
 

--- a/tests/parsers/directive.parser.spec.ts
+++ b/tests/parsers/directive.parser.spec.ts
@@ -118,4 +118,10 @@ describe('DirectiveParser', () => {
 		expect(template).to.equal('<p translate="KEY">Hello World</p>');
 	});
 
+	it('should extract contents from within custom tags', () => {
+		const contents = `<custom-table><tbody><tr><td translate>Hello World</td></tr></tbody></custom-table>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['Hello World']);
+	});
+
 });


### PR DESCRIPTION
Cheerio ignored the content of non-standard HTML tags.
I configured cheerio in xml mode, so it supports custom tags, which you usually have in Angular, when you create your own Components.

Now something like this gets extracted, too:
`<custom-table><tbody><tr><td translate>Hello World</td></tr></tbody></custom-table>`