### PR TITLE
docs: fixes path for extract npm script example

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install the package in your project:
 Add an `extract` script to your project's `package.json`:
 ```
 "scripts": {
-  "extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/*.json --clean --sort --format namespaced-json"
+  "extract": "ngx-translate-extract --input ./src --output ./src/assets/i18n/ --clean --sort --format namespaced-json"
 }
 ```
 You can now run `npm run extract` to extract strings.


### PR DESCRIPTION
The example script gives the following error on windows:

Saving: <project dir>\src\assets\i18n\*.json
- sorted strings
fs.js:652
  return binding.open(pathModule._makeLong(path), stringToFlags(flags), mode);
                 ^

Error: ENOENT: no such file or directory, open '<project dir>\src\assets\i18n\*.json'