### PR TITLE
cli: actually do something with the verbose option

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -95,7 +95,8 @@ const extract = new ExtractTask(cli.input, cli.output, {
 	replace: cli.replace,
 	sort: cli.sort,
 	clean: cli.clean,
-	patterns: cli.patterns
+	patterns: cli.patterns,
+	verbose: cli.verbose
 });
 
 const compiler: CompilerInterface = CompilerFactory.create(cli.format, {


### PR DESCRIPTION
Previously it was never passed to ExtractTask and the default was used