### PR TITLE
Issue #80: filtering variables from the list of arguments

### DIFF
--- a/src/parsers/abstract-ast.parser.ts
+++ b/src/parsers/abstract-ast.parser.ts
@@ -23,6 +23,7 @@ export abstract class AbstractAstParser {
 				return [(firstArg as ts.StringLiteral).text];
 			case ts.SyntaxKind.ArrayLiteralExpression:
 				return (firstArg as ts.ArrayLiteralExpression).elements
+					.filter((element: ts.Expression) => element.kind !== ts.SyntaxKind.Identifier)
 					.map((element: ts.StringLiteral) => element.text);
 			case ts.SyntaxKind.Identifier:
 				console.log('WARNING: We cannot extract variable values passed to TranslateService (yet)');


### PR DESCRIPTION
In case translateService.get is called with a list of arguments and one or more are of type 'identifier' these should not be extracted.

Explanation of the issue: 

```TypeScript
translateService.get(["yes", variable ]).then(translations => {
  console.log(translations[variable]);
});
```
This will cause the extracted JSON to include 'variable', which it should not.

```JSON
{
  "yes": "",
  "variable": ""
}
```