### PR TITLE
Handle split strings

### DIFF
--- a/src/parsers/abstract-ast.parser.ts
+++ b/src/parsers/abstract-ast.parser.ts
@@ -17,18 +17,37 @@ export abstract class AbstractAstParser {
 		}
 
 		const firstArg = callNode.arguments[0];
-		switch (firstArg.kind) {
+		return this._getStringsFromExpression(firstArg);
+	}
+
+	/**
+	 * Get strings from an arbitrary JS expression
+	 */
+	protected _getStringsFromExpression(expression: ts.Expression): string[] {
+		switch (expression.kind) {
 			case ts.SyntaxKind.StringLiteral:
 			case ts.SyntaxKind.FirstTemplateToken:
-				return [(firstArg as ts.StringLiteral).text];
+				// Example: __('This is a sentence.')
+				return [(expression as ts.StringLiteral).text];
 			case ts.SyntaxKind.ArrayLiteralExpression:
-				return (firstArg as ts.ArrayLiteralExpression).elements
+				return (expression as ts.ArrayLiteralExpression).elements
 					.map((element: ts.StringLiteral) => element.text);
+			case ts.SyntaxKind.BinaryExpression:
+				// Example: __('str1' + 'str2')
+				const binExp = expression as ts.BinaryExpression;
+				const left = this._getStringsFromExpression(binExp.left)[0],
+				      right = this._getStringsFromExpression(binExp.right)[0];
+				if (binExp.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+					typeof left === 'string' && typeof right === 'string') {
+					return [left + right];
+				}
+				console.log(`SKIP: Unknown BinaryExpression: `, expression);
+				break;
 			case ts.SyntaxKind.Identifier:
 				console.log('WARNING: We cannot extract variable values passed to TranslateService (yet)');
 				break;
 			default:
-				console.log(`SKIP: Unknown argument type: '${this._syntaxKindToName(firstArg.kind)}'`, firstArg);
+				console.log(`SKIP: Unknown argument type: '${this._syntaxKindToName(expression.kind)}'`, expression);
 		}
 	}
 

--- a/tests/parsers/function.parser.spec.ts
+++ b/tests/parsers/function.parser.spec.ts
@@ -24,4 +24,19 @@ describe('FunctionParser', () => {
 		expect(keys).to.deep.equal(['Hello world', 'I', 'am', 'extracted']);
 	});
 
+	it('should extract split strings', () => {
+		const contents = `
+			import { _ } from '@biesbjerg/ngx-translate-extract';
+			_('Hello ' + 'world');
+			_('This is a ' + 'very ' + 'very ' + 'very ' + 'very ' + 'long line.');
+			_('Mix ' + \`of \` + 'different ' + \`types\`);
+		`;
+		const keys = parser.extract(contents, componentFilename).keys();
+		expect(keys).to.deep.equal([
+			'Hello world',
+			'This is a very very very very long line.',
+			'Mix of different types',
+		]);
+	});
+
 });


### PR DESCRIPTION
Correctly handle concatenations of strings like:

```js
_('Hello ' + 'world')
```

or:

```js
_('This is a very, very, very, very, very, very, ' +
  'long sentence that spreads accross multiple lines.')
```