### PR TITLE
fix(marker) function _ same value return with generics

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,3 @@
-export function _(key: string | string[]): string | string[] {
+export function _<T extends string | string[]>(key: T) : T{
 	return key;
 }


### PR DESCRIPTION
Marker function `_`  could not be used directly in place of string because of its return type `string | string[]`. 

![image](https://user-images.githubusercontent.com/6958290/61525637-1bdec780-aa19-11e9-8bd4-3865852d9b08.png)

I have modified it to return same type as given.

The tests are passing.