### PR TITLE
(feat) cli option to add newline at end of file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,13 +77,12 @@ Usage:
 ngx-translate-extract [options]
 
 Options:
-  --version, -v               Show version number                      [boolean]
-  --help, -h                  Show help                                [boolean]
-  --input, -i                 Paths you would like to extract strings from. You
-                              can use path expansion, glob patterns and multiple
-                              paths
-                      [array] [default: current working path]
-     [array] [required] [default: current working path]
+  --version, -v                Show version number                     [boolean]
+  --help, -h                   Show help                               [boolean]
+  --input, -i                  Paths you would like to extract strings from. You
+                               can use path expansion, glob patterns and
+                               multiple paths
+                                            [array] [required] [default: [null]]
   --patterns, -p               Extract strings from the following file patterns
                                     [array] [default: ["/**/*.html","/**/*.ts"]]
   --output, -o                 Paths where you would like to save extracted
@@ -91,7 +90,9 @@ Options:
                                patterns and multiple paths    [array] [required]
   --format, -f                 Output format
           [string] [choices: "json", "namespaced-json", "pot"] [default: "json"]
-  --format-indentation, --fi   Output format indentation  [string] [default: "	"]
+  --format-indentation, --fi   Output format indentation  [string] [default: "  "]
+  --newline-at-eof, --fn       Adds newline to the end of output
+                                                      [boolean] [default: false]
   --replace, -r                Replace the contents of output file if it exists
                                (Merges by default)                     [boolean]
   --sort, -s                   Sort strings in alphabetical order when saving

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -64,6 +64,12 @@ export const cli = yargs
 		default: '\t',
 		type: 'string'
 	})
+	.option('newline-at-eof', {
+		alias: 'fn',
+		describe: 'Adds newline to the end of output',
+		default: false,
+		type: 'boolean'
+	})
 	.option('replace', {
 		alias: 'r',
 		describe: 'Replace the contents of output file if it exists (Merges by default)',
@@ -119,7 +125,8 @@ extractTask.setPostProcessors(postProcessors);
 
 // Compiler
 const compiler: CompilerInterface = CompilerFactory.create(cli.format, {
-	indentation: cli.formatIndentation
+	indentation: cli.formatIndentation,
+	newlineAtEndOfFile: cli.newlineAtEof
 });
 extractTask.setCompiler(compiler);
 

--- a/src/compilers/json.compiler.ts
+++ b/src/compilers/json.compiler.ts
@@ -6,17 +6,28 @@ import { flatten } from 'flat';
 
 export class JsonCompiler implements CompilerInterface {
 	public indentation: string = '\t';
+	public newlineAtEndOfFile = false;
 
 	public extension: string = 'json';
 
 	public constructor(options?: any) {
-		if (options && typeof options.indentation !== 'undefined') {
+		if (!options) {
+			return; // no options
+		}
+		if (typeof options.indentation !== 'undefined') {
 			this.indentation = options.indentation;
+		}
+		if (typeof options.newlineAtEndOfFile !== 'undefined') {
+			this.newlineAtEndOfFile = options.newlineAtEndOfFile;
 		}
 	}
 
 	public compile(collection: TranslationCollection): string {
-		return JSON.stringify(collection.values, null, this.indentation);
+		let json = JSON.stringify(collection.values, null, this.indentation);
+		if (this.newlineAtEndOfFile) {
+			json += '\n';
+		}
+		return json;
 	}
 
 	public parse(contents: string): TranslationCollection {

--- a/src/compilers/namespaced-json.compiler.ts
+++ b/src/compilers/namespaced-json.compiler.ts
@@ -6,12 +6,19 @@ import { flatten, unflatten } from 'flat';
 
 export class NamespacedJsonCompiler implements CompilerInterface {
 	public indentation: string = '\t';
+	public newlineAtEndOfFile = false;
 
 	public extension = 'json';
 
 	public constructor(options?: any) {
-		if (options && typeof options.indentation !== 'undefined') {
+		if (!options) {
+			return; // no options
+		}
+		if (typeof options.indentation !== 'undefined') {
 			this.indentation = options.indentation;
+		}
+		if (typeof options.newlineAtEndOfFile !== 'undefined') {
+			this.newlineAtEndOfFile = options.newlineAtEndOfFile;
 		}
 	}
 
@@ -19,7 +26,11 @@ export class NamespacedJsonCompiler implements CompilerInterface {
 		const values: {} = unflatten(collection.values, {
 			object: true
 		});
-		return JSON.stringify(values, null, this.indentation);
+		let json = JSON.stringify(values, null, this.indentation);
+		if (this.newlineAtEndOfFile) {
+			json += '\n';
+		}
+		return json;
 	}
 
 	public parse(contents: string): TranslationCollection {

--- a/tests/compilers/json.compiler.spec.ts
+++ b/tests/compilers/json.compiler.spec.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+
+import { TranslationCollection } from '../../src/utils/translation.collection';
+import { JsonCompiler } from '../../src/compilers/json.compiler';
+
+describe('JsonCompiler', () => {
+	it("should construct without options", () => {
+		expect(() => new JsonCompiler()).to.not.throw();
+	});
+
+	it('should compile to json', () => {
+		const customCompiler = new JsonCompiler();
+		const result: string = customCompiler.compile(testData());
+		expect(result).to.equal('{\n\t"FIRST_KEY": "",\n\t"SECOND_KEY": "VALUE"\n}');
+	});
+	
+	it('should add newline to end of file when requested', () => {
+		const customCompiler = new JsonCompiler({
+			newlineAtEndOfFile : true
+		});
+		const result: string = customCompiler.compile(testData());
+		expect(result.endsWith('\n'))
+			.to.equal(true, 'result should end with newline');
+	});
+	
+	it('should use custom indentation chars', () => {
+		const customCompiler = new JsonCompiler({
+			indentation: '  '
+		});
+		const result: string = customCompiler.compile(testData());
+		expect(result).to.equal('{\n  "FIRST_KEY": "",\n  "SECOND_KEY": "VALUE"\n}');
+	});
+	
+	const testData = () => new TranslationCollection({
+		'FIRST_KEY': '',
+		'SECOND_KEY': 'VALUE'
+	});
+});

--- a/tests/compilers/namespaced-json.compiler.spec.ts
+++ b/tests/compilers/namespaced-json.compiler.spec.ts
@@ -59,6 +59,19 @@ describe('NamespacedJsonCompiler', () => {
 		expect(result).to.equal('{\n  "NAMESPACE": {\n    "KEY": {\n      "FIRST_KEY": "",\n      "SECOND_KEY": "VALUE"\n    }\n  }\n}');
 	});
 
+	it('should add newline to end of file when requested', () => {
+		const collection = new TranslationCollection({
+			'NAMESPACE.KEY.FIRST_KEY': '',
+			'NAMESPACE.KEY.SECOND_KEY': 'VALUE'
+		});
+		const customCompiler = new NamespacedJsonCompiler({
+			indentation: '  ',
+            newlineAtEndOfFile : true
+		});
+		const result: string = customCompiler.compile(collection);
+		expect(result).to.equal('{\n  "NAMESPACE": {\n    "KEY": {\n      "FIRST_KEY": "",\n      "SECOND_KEY": "VALUE"\n    }\n  }\n}\n');
+	});
+
 	it('should not reorder keys when compiled', () => {
 		const collection = new TranslationCollection({
 			BROWSE: '',


### PR DESCRIPTION
This PR adds a new feature to allow users to configure whether they want a newline char at the end of the file or not. I set it to disabled by default so that it does not break people's existing systems.

The motivation behind this is to reduce the number of merge conflicts caused by editors formatting. It would fix a lot of issues on one of the projects I'm working on. And by this being an option it's not forcing anyone to switch to anything, win-win!

I also added some tests to json.compiler.ts as there were none.

I've been getting a wierd error from husky when trying to add a new test file:

    gx-translate-extract\tests\compilers\json.compiler.spec.ts' is not included in project.

I fixed all other linter issues, all tests pass, but I had to skip this check otherwise there would be no tests at all for json.compiler.ts, which is not good either.

Let me know what you think!