### PR TITLE
Parse Pipes with Angular Compiler AST, enable ternary operator parsing

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -66,17 +66,17 @@ export class PipeParser implements ParserInterface {
 		return ret;
 	}
 
-	protected parseTranslationKeysFromPipe(pipe: BindingPipe): string[] {
+	protected parseTranslationKeysFromPipe(pipeContent: BindingPipe | LiteralPrimitive | Conditional): string[] {
 		const ret: string[] = [];
-		if (pipe.exp instanceof LiteralPrimitive) {
-			ret.push(pipe.exp.value);
-		} else if (pipe.exp instanceof Conditional) {
-			const trueExp: LiteralPrimitive = (pipe.exp.trueExp as any) as LiteralPrimitive;
-			const falseExp: LiteralPrimitive = (pipe.exp.falseExp as any) as LiteralPrimitive;
-			ret.push(trueExp.value);
-			ret.push(falseExp.value);
-		} else if (pipe.exp instanceof BindingPipe) {
-			ret.push(...this.parseTranslationKeysFromPipe(pipe.exp));
+		if (pipeContent instanceof LiteralPrimitive) {
+			ret.push(pipeContent.value);
+		} else if (pipeContent instanceof Conditional) {
+			const trueExp: LiteralPrimitive | Conditional = pipeContent.trueExp as any;
+			ret.push(...this.parseTranslationKeysFromPipe(trueExp));
+			const falseExp: LiteralPrimitive | Conditional = pipeContent.falseExp as any;
+			ret.push(...this.parseTranslationKeysFromPipe(falseExp));
+		} else if (pipeContent instanceof BindingPipe) {
+			ret.push(...this.parseTranslationKeysFromPipe(pipeContent.exp as any));
 		}
 		return ret;
 	}

--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -1,6 +1,7 @@
 import { ParserInterface } from './parser.interface';
 import { TranslationCollection } from '../utils/translation.collection';
 import { isPathAngularComponent, extractComponentInlineTemplate } from '../utils/utils';
+import { TmplAstNode, parseTemplate, BindingPipe, LiteralPrimitive, Conditional, TmplAstTextAttribute } from '@angular/compiler';
 
 export class PipeParser implements ParserInterface {
 	public extract(source: string, filePath: string): TranslationCollection | null {
@@ -8,18 +9,89 @@ export class PipeParser implements ParserInterface {
 			source = extractComponentInlineTemplate(source);
 		}
 
-		return this.parseTemplate(source);
+		let collection: TranslationCollection = new TranslationCollection();
+		const nodes: TmplAstNode[] = this.parseTemplate(source, filePath);
+		const pipes: BindingPipe[] = nodes.map(node => this.findPipesInNode(node)).flat();
+		pipes.forEach(pipe => {
+			this.parseTranslationKeysFromPipe(pipe).forEach((key: string) => {
+				collection = collection.add(key);
+			});
+		});
+		return collection;
 	}
 
-	protected parseTemplate(template: string): TranslationCollection {
-		let collection: TranslationCollection = new TranslationCollection();
+	protected findPipesInNode(node: any): BindingPipe[] {
+		let ret: BindingPipe[] = [];
 
-		const regExp: RegExp = /(['"`])((?:(?!\1).|\\\1)+)\1\s*\|\s*translate/g;
-		let matches: RegExpExecArray;
-		while ((matches = regExp.exec(template))) {
-			collection = collection.add(matches[2].split("\\'").join("'"));
+		if (node.children) {
+			ret = node.children.reduce(
+				(result: BindingPipe[], childNode: TmplAstNode) => {
+					const children = this.findPipesInNode(childNode);
+					return result.concat(children);
+				},
+				[ret]
+			);
 		}
 
-		return collection;
+		if (node.value && node.value.ast && node.value.ast.expressions) {
+			const translateables = node.value.ast.expressions.filter((exp: any) => this.expressionIsOrHasBindingPipe(exp));
+			ret.push(...translateables);
+		}
+
+		if (node.attributes) {
+			const translateableAttributes = node.attributes.filter((attr: TmplAstTextAttribute) => {
+				return attr.name === 'translate';
+			});
+			ret = [...ret, ...translateableAttributes];
+		}
+
+		if (node.inputs) {
+			node.inputs.forEach((input: any) => {
+				// <element [attrib]="'identifier' | translate">
+				if (input.value && input.value.ast && this.expressionIsOrHasBindingPipe(input.value.ast)) {
+					ret.push(input.value.ast);
+				}
+
+				// <element attrib="{{'identifier' | translate}}>"
+				if (input.value && input.value.ast && input.value.ast.expressions) {
+					input.value.ast.expressions.forEach((exp: BindingPipe) => {
+						if (this.expressionIsOrHasBindingPipe(exp)) {
+							ret.push(exp);
+						}
+					});
+				}
+			});
+		}
+
+		return ret;
+	}
+
+	protected parseTranslationKeysFromPipe(pipe: BindingPipe): string[] {
+		const ret: string[] = [];
+		if (pipe.exp instanceof LiteralPrimitive) {
+			ret.push(pipe.exp.value);
+		} else if (pipe.exp instanceof Conditional) {
+			const trueExp: LiteralPrimitive = (pipe.exp.trueExp as any) as LiteralPrimitive;
+			const falseExp: LiteralPrimitive = (pipe.exp.falseExp as any) as LiteralPrimitive;
+			ret.push(trueExp.value);
+			ret.push(falseExp.value);
+		} else if (pipe.exp instanceof BindingPipe) {
+			ret.push(...this.parseTranslationKeysFromPipe(pipe.exp));
+		}
+		return ret;
+	}
+
+	protected expressionIsOrHasBindingPipe(exp: any): boolean {
+		if (exp.name && exp.name === 'translate') {
+			return true;
+		}
+		if (exp.exp && exp.exp instanceof BindingPipe) {
+			return this.expressionIsOrHasBindingPipe(exp.exp);
+		}
+		return false;
+	}
+
+	protected parseTemplate(template: string, path: string): TmplAstNode[] {
+		return parseTemplate(template, path).nodes;
 	}
 }

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -29,10 +29,34 @@ describe('PipeParser', () => {
 		expect(keys).to.deep.equal(['World']);
 	});
 
-	it('should extract interpolated strings when translate pipe is used in conjunction with other pipes', () => {
+	it('should extract interpolated strings when translate pipe is used before other pipes', () => {
 		const contents = `Hello {{ 'World' | translate | upper }}`;
 		const keys = parser.extract(contents, templateFilename).keys();
 		expect(keys).to.deep.equal(['World']);
+	});
+
+	it('should extract interpolated strings when translate pipe is used after other pipes', () => {
+		const contents = `Hello {{ 'World'  | upper | translate }}`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['World']);
+	});
+
+	it('should extract strings from ternary operators inside interpolations', () => {
+		const contents = `{{ (condition ? 'Hello' : 'World') | translate }}`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['Hello', 'World']);
+	});
+
+	it('should extract strings from ternary operators inside attribute bindings', () => {
+		const contents = `<span [attr]="(condition ? 'Hello' : 'World') | translate"></span>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['Hello', 'World']);
+	});
+
+	it('should extract strings from ternary operators inside attribute interpolations', () => {
+		const contents = `<span attr="{{(condition ? 'Hello' : 'World') | translate}}"></span>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['Hello', 'World']);
 	});
 
 	it('should extract strings with escaped quotes', () => {
@@ -59,7 +83,7 @@ describe('PipeParser', () => {
 		expect(keys).to.deep.equal(['Hello World']);
 	});
 
-	it('should not use a greedy regular expression', () => {
+	it('should extract multiple entries from nodes', () => {
 		const contents = `
 			<ion-header>
 				<ion-navbar color="brand">

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -53,6 +53,12 @@ describe('PipeParser', () => {
 		expect(keys).to.deep.equal(['Hello', 'World']);
 	});
 
+	it('should extract strings from nested ternary operators ', () => {
+		const contents = `<h3>{{ (condition ? 'Hello' : anotherCondition ? 'Nested' : 'World' ) | translate }}</h3>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal(['Hello', 'Nested', 'World']);
+	});
+
 	it('should extract strings from ternary operators inside attribute interpolations', () => {
 		const contents = `<span attr="{{(condition ? 'Hello' : 'World') | translate}}"></span>`;
 		const keys = parser.extract(contents, templateFilename).keys();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "target": "es2015",
         "lib": [
             "dom",
-            "es2018"
+            "esnext.array"
         ],
         "module": "commonjs",
         "outDir": "./dist/",
@@ -25,7 +25,6 @@
         "tests/**/*.ts"
     ],
     "exclude": [
-        "node_modules",
-        "tests/**/*.ts"
+        "node_modules"
     ]
 }


### PR DESCRIPTION
After toying around with (and cursing about) RegEx-based solutions, I decided to dig a little deeper and create a AST-based approach to translate pipe parsing.

Fixes #111, Fixes #154 
Also enables parsing translate pipes from any position in a pipe chain.

Test are working & extended.