### PR TITLE
Add custom default value argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ Options:
   --sort, -s                   Sort strings in alphabetical order when saving
                                                                        [boolean]
   --clean, -c                  Remove obsolete strings when merging    [boolean]
+  --custom-default-value, --cu Use custom default value for translations.
+                               Default: Missing translation.
+                                                                       [string]
   --key-as-default-value, -k   Use key as default value for translations
                                                                        [boolean]
   --null-as-default-value, -n  Use null as default value for translations

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -9,6 +9,7 @@ import { ServiceParser } from '../parsers/service.parser';
 import { MarkerParser } from '../parsers/marker.parser';
 import { PostProcessorInterface } from '../post-processors/post-processor.interface';
 import { SortByKeyPostProcessor } from '../post-processors/sort-by-key.post-processor';
+import { CustomDefaultValuePostProcessor } from '../post-processors/custom-default-value.post-processor';
 import { KeyAsDefaultValuePostProcessor } from '../post-processors/key-as-default-value.post-processor';
 import { NullAsDefaultValuePostProcessor } from '../post-processors/null-as-default-value.post-processor';
 import { PurgeObsoleteKeysPostProcessor } from '../post-processors/purge-obsolete-keys.post-processor';
@@ -79,17 +80,24 @@ export const cli = yargs
 		describe: 'Remove obsolete strings when merging',
 		type: 'boolean'
 	})
+	.option('custom-default-value', {
+		alias: 'cu',
+		describe: 'Use custom default value for translations',
+		type: 'string',
+		conflicts: ['key-as-default-value', 'null-as-default-value']
+	})
 	.option('key-as-default-value', {
 		alias: 'k',
 		describe: 'Use key as default value for translations',
-		type: 'boolean'
+		type: 'boolean',
+		conflicts: ['custom-default-value', 'null-as-default-value']
 	})
 	.option('null-as-default-value', {
 		alias: 'n',
 		describe: 'Use null as default value for translations',
-		type: 'boolean'
+		type: 'boolean',
+		conflicts: ['custom-default-value', 'key-as-default-value']
 	})
-	.conflicts('key-as-default-value', 'null-as-default-value')
 	.exitProcess(true)
 	.parse(process.argv);
 
@@ -107,7 +115,9 @@ const postProcessors: PostProcessorInterface[] = [];
 if (cli.clean) {
 	postProcessors.push(new PurgeObsoleteKeysPostProcessor());
 }
-if (cli.keyAsDefaultValue) {
+if (typeof cli.customDefaultValue === 'string') {
+	postProcessors.push(new CustomDefaultValuePostProcessor(cli.customDefaultValue));
+} else if (cli.keyAsDefaultValue) {
 	postProcessors.push(new KeyAsDefaultValuePostProcessor());
 } else if (cli.nullAsDefaultValue) {
 	postProcessors.push(new NullAsDefaultValuePostProcessor());

--- a/src/post-processors/custom-default-value.post-processor.ts
+++ b/src/post-processors/custom-default-value.post-processor.ts
@@ -1,0 +1,17 @@
+import { TranslationCollection } from '../utils/translation.collection';
+import { PostProcessorInterface } from './post-processor.interface';
+
+const MISSING_TRANSLATION = 'Missing translation';
+
+export class CustomDefaultValuePostProcessor implements PostProcessorInterface {
+	public name: string = 'CustomDefaultValue';
+	private value: string;
+
+	constructor(value: string) {
+		this.value = value;
+	}
+
+	public process(draft: TranslationCollection): TranslationCollection {
+		return draft.map((_, val) => (val ? val : this.value ? this.value : MISSING_TRANSLATION));
+	}
+}

--- a/src/post-processors/post-processor.interface.ts
+++ b/src/post-processors/post-processor.interface.ts
@@ -3,5 +3,5 @@ import { TranslationCollection } from '../utils/translation.collection';
 export interface PostProcessorInterface {
 	name: string;
 
-	process(draft: TranslationCollection, extracted: TranslationCollection, existing: TranslationCollection): TranslationCollection;
+	process(draft: TranslationCollection, extracted?: TranslationCollection, existing?: TranslationCollection): TranslationCollection;
 }

--- a/tests/post-processors/custom-default-value.post-processor.spec.ts
+++ b/tests/post-processors/custom-default-value.post-processor.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+
+import { PostProcessorInterface } from '../../src/post-processors/post-processor.interface';
+import { CustomDefaultValuePostProcessor } from '../../src/post-processors/custom-default-value.post-processor';
+import { TranslationCollection } from '../../src/utils/translation.collection';
+
+describe('CustomDefaultValuePostProcessor', () => {
+	let processor: PostProcessorInterface;
+
+	it('should keep the same value', () => {
+		processor = new CustomDefaultValuePostProcessor('Missing translation');
+		const collection = new TranslationCollection({ 'existing.value': 'Hello' });
+
+		expect(processor.process(collection).values).to.deep.equal({
+			'existing.value': 'Hello'
+		});
+	});
+
+	it('should use the custom default value', () => {
+		processor = new CustomDefaultValuePostProcessor('');
+		const collection = new TranslationCollection({ 'no.value': '' });
+
+		expect(processor.process(collection).values).to.deep.equal({
+			'no.value': 'Missing translation'
+		});
+	});
+
+	it('should use the custom value', () => {
+		processor = new CustomDefaultValuePostProcessor('Missing');
+		const collection = new TranslationCollection({ 'no.value': '' });
+
+		expect(processor.process(collection).values).to.deep.equal({
+			'no.value': 'Missing'
+		});
+	});
+});


### PR DESCRIPTION
Add new argument `--cu` to set a custom default value on key extraction.
Takes a default value "Missing translation" if no value is passed.
Fix #40.