### PR TITLE
Enable pipes as arguments on function calls

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -9,7 +9,8 @@ import {
 	Binary,
 	LiteralMap,
 	LiteralArray,
-	Interpolation
+	Interpolation,
+	MethodCall
 } from '@angular/compiler';
 
 import { ParserInterface } from './parser.interface';
@@ -129,6 +130,10 @@ export class PipeParser implements ParserInterface {
 		// - [ 'value1' | translate, 'value2' | translate ]
 		if (ast instanceof LiteralArray) {
 			return this.getTranslatablesFromAsts(ast.expressions);
+		}
+
+		if (ast instanceof MethodCall) {
+			return this.getTranslatablesFromAsts(ast.args);
 		}
 
 		return [];

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -195,4 +195,10 @@ describe('PipeParser', () => {
 		const keys = parser.extract(contents, templateFilename).keys();
 		expect(keys).to.deep.equal([]);
 	});
+
+	it('should extract strings from piped arguments inside a function calls on templates', () => {
+		const contents = `{{ callMe('Hello' | translate, 'World' | translate ) }}`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal([`Hello`, `World`]);
+	});
 });


### PR DESCRIPTION
We have found an use case where translate pipes were not being extracted when switching to versión 7.x

```html
<strong>{{ call('SOME.LITERAL' | translate) }}</strong>
```


