### PR TITLE
Find pipe uses in inputs to structural directives

### DIFF
--- a/src/parsers/pipe.parser.ts
+++ b/src/parsers/pipe.parser.ts
@@ -68,6 +68,14 @@ export class PipeParser implements ParserInterface {
 				}
 			});
 		}
+		if (node?.templateAttrs) {
+			node.templateAttrs.forEach((attr: any) => {
+				// <element *directive="'identifier' | translate">
+				if (attr?.value?.ast) {
+					ret.push(...this.getTranslatablesFromAst(attr.value.ast));
+				}
+			});
+		}
 
 		return ret;
 	}

--- a/tests/parsers/pipe.parser.spec.ts
+++ b/tests/parsers/pipe.parser.spec.ts
@@ -201,4 +201,31 @@ describe('PipeParser', () => {
 		const keys = parser.extract(contents, templateFilename).keys();
 		expect(keys).to.deep.equal([`Hello`, `World`]);
 	});
+
+	it('should extract from objects in property bindings', () => {
+		const contents = `
+		<hello [values]="{
+			hello: ('Hello' | translate),
+			world: ('World' | translate) }"></hello>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal([`Hello`, `World`]);
+	});
+
+	it('should extract from structural directives', () => {
+		const contents = `
+		<ng-container *ngIf="'Hello' | translate as hello">{{hello}}</ng-container>
+		`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal([`Hello`]);
+	});
+
+	it('should extract form inputs to structural directives', () => {
+		const contents = `
+		<ng-container *ngTemplateOutlet="template ; context:{
+			hello: 'Hello' | translate,
+			world: 'World' | translate,
+		}"></ng-container>`;
+		const keys = parser.extract(contents, templateFilename).keys();
+		expect(keys).to.deep.equal([`Hello`, `World`]);
+	});
 });


### PR DESCRIPTION
After finally upgrading from 3.0.5 to a recent version we've noticed the pipe parser no longer detects usages like this:

```html
<ng-container *ngTemplateOutlet="section; context: {
  title: 'example.translation.key' | translate
}"></ng-container>
```

Turns out it's because inputs to structural directives were not being searched at all. 

This PR adds handling of `templateAttrs` on `Template` nodes that works identically to inputs.